### PR TITLE
Remove bare ints from tq query

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ that these should be used such that they do not interfere with shell quoting.
 | :-------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------: |
 | <kbd><b>identity</b></kbd>                                                  | <kbd><b>.</b></kbd>                                                                                 |
 | <kbd><b>key</b></kbd>                                                       | <kbd><b>["string"]</b></kbd> or <kbd><b>"quoted string"</b></kbd> or <kbd><b>bare-string</b></kbd>  |
-| <kbd><b>index</b></kbd>                                                     | <kbd><b>[0]</b></kbd> or <kbd><b>0</b></kbd>                                                        |
+| <kbd><b>index</b></kbd>                                                     | <kbd><b>[0]</b></kbd>                                                                               |
 | <kbd><b>iterator</b></kbd>                                                  | <kbd><b>[]</b></kbd>                                                                                |
 | <kbd><b>span</b></kbd>                                                      | <kbd><b>[:]</b></kbd>                                                                               |
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -70,10 +70,6 @@ func (p *Parser) filter() (ast.Filter, error) {
 		var s ast.String
 		s, err = p.string()
 		expr.Kind = &s
-	case p.match(lexer.Integer):
-		var s ast.Integer
-		s, err = p.integer()
-		expr.Kind = &s
 	default:
 		v, _ := p.peek()
 		err = &Error{v.Lexeme(), v.Buffer, v.Start, v.LineOffset, ErrQueryElement}


### PR DESCRIPTION
Bare ints are misleading when used the same way one would use bare strings. It is better to keep them as an internal element of a selector.
