### PR TITLE
Bump Go version and Github workflow action versions

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,7 +37,7 @@ jobs:
       run: go test -v -coverprofile='coverage.txt' -covermode='atomic' ./...
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5.4.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,19 +10,19 @@ jobs:
   build:
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
         os: [ windows-latest, macos-latest, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.go }}/${{ matrix.os }}
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v4.1.0
+      uses: actions/setup-go@v5.4.0
       with:
         go-version: ${{ matrix.go }}
 
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.2.0
       with:
         fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v5.4.0
         with:
           go-version: '1.23'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Login to Github container registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.2.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           go-version: '1.24'
 
       - name: Login to Github container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6.3.0
         with:
           distribution: goreleaser
           version: latest

--- a/Makefile
+++ b/Makefile
@@ -6,30 +6,34 @@ export CGO_ENABLED=0
 
 .DEFAULT_GOAL := build
 
+ifndef VERBOSE
+.SILENT:
+endif
+
 .PHONY: fmt vet test install build cover clean
 
 fmt:
-	@$(GO) fmt ./...
+	$(GO) fmt ./...
 
 vet: fmt
-	@$(GO) vet ./...
+	$(GO) vet ./...
 
 test: vet
-	@$(GO) clean -testcache
-	@$(GO) test ./... -v
+	$(GO) clean -testcache
+	$(GO) test ./... -v
 
 install: test
-	@$(GO) install ./...
+	$(GO) install ./...
 
 build: test
-	@$(GO) build $(GOFLAGS) github.com/mdm-code/tq/...
+	$(GO) build $(GOFLAGS) github.com/mdm-code/tq/...
 
 cover:
-	@$(GO) test -coverprofile=$(COV_PROFILE) -covermode=atomic ./...
-	@$(GO) tool cover -html=$(COV_PROFILE)
+	$(GO) test -coverprofile=$(COV_PROFILE) -covermode=atomic ./...
+	$(GO) tool cover -html=$(COV_PROFILE)
 
 clean:
-	@$(GO) clean github.com/mdm-code/tq/...
-	@$(GO) mod tidy
-	@$(GO) clean -testcache
-	@rm -f $(COV_PROFILE)
+	$(GO) clean github.com/mdm-code/tq/...
+	$(GO) mod tidy
+	$(GO) clean -testcache
+	rm -f $(COV_PROFILE)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ endif
 
 .PHONY: fmt vet test install build cover clean
 
+.PHONY: .ONESHELL
+.ONESHELL:
+
 fmt:
 	$(GO) fmt ./...
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ and linting that can be used locally for development purposes.
 
 ## License
 
-Copyright (c) 2024 Michał Adamczyk.
+Copyright (c) 2025 Michał Adamczyk.
 
 This project is licensed under the [MIT license](https://opensource.org/licenses/MIT).
 See [LICENSE](LICENSE) for more details.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdm-code/tq/v2
 
-go 1.23
+go 1.24
 
 require (
 	github.com/mdm-code/scanner v1.2.1


### PR DESCRIPTION
- **Updated copyright date in the README file**
- **Configured Makefile verbosiity**
- **Enabled one shell spawned per target**
- **Bumped Go version in go.mod file to 1.24**
- **Updated checkout action in GH workflow to 4.2.0**
- **Updated setup-go action in GH workflow to 5.4.0**
- **Bumped GH release workflow Go version to 1.24**
- **Introduced the same changes to to main workflow**
- **Specified docker login GH action to 3.4.0**
- **Updated Goreleaser GH workflow action to 6.3.0**
- **Updated codecov GH workflow action to 5.4.0**
