### PR TITLE
Remove quotes around single output strings; remove trailing newline character

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Michał Adamczyk
+Copyright (c) 2025 Michał Adamczyk
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ EOF
 
 Output:
 
-'/home/core/data/gitlab-runner/data'
+/home/core/data/gitlab-runner/data
 ```
 
 
@@ -219,8 +219,8 @@ EOF
 
 Output:
 
-'10.0.0.1'
-'10.0.0.2'
+10.0.0.1
+10.0.0.2
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ to an iterator with `[]`, and then (5) query each element of the iterator for
 
 
 ```sh
-tq -q '
+<< EOF tq -q '
     .runners[]
         .kubernetes
         .volumes
         .host_path[]
             ."host path"
-' << EOF
+'
 [session_server]
   session_timeout = 1800
 
@@ -190,7 +190,9 @@ tq -q '
     pod_annotations_overwrite_allowed = ""
     [runners.kubernetes.volumes]
 EOF
+```
 
+```txt
 Output:
 
 /home/core/data/gitlab-runner/data
@@ -205,7 +207,7 @@ with `[]`, and then (3) the IP address is recovered from each of the objects
 with the quoted key `"ip"`.
 
 ```sh
-tq -q '.servers[]."ip"' <<EOF
+<<EOF tq -q '.servers[]."ip"'
 [servers]
 
 [servers.prod]
@@ -216,7 +218,9 @@ role = "backend"
 ip = "10.0.0.2"
 role = "backend"
 EOF
+```
 
+```txt
 Output:
 
 10.0.0.1
@@ -231,10 +235,12 @@ all ports aside from the first one assigned to the first database record on the
 list.
 
 ```sh
-tq -q '.["databases"][0]["ports"][1:][]' <<EOF
+<<EOF tq -q '.["databases"][0]["ports"][1:][]'
 databases = [ {enabled = true, ports = [ 5432, 5433, 5434 ]} ]
 EOF
+```
 
+```txt
 Output:
 
 5433
@@ -248,7 +254,7 @@ If you don't feel like installing `tq` with `go install`, you can test `tq` out
 running inside of a container with this command:
 
 ```sh
-docker run -i ghcr.io/mdm-code/tq:latest tq -q ".dependencies.ignore" <<EOF
+<<EOF docker run -i ghcr.io/mdm-code/tq:latest tq -q ".dependencies.ignore"
 [dependencies]
 anyhow = "1.0.75"
 bstr = "1.7.0"
@@ -260,6 +266,13 @@ serde_json = "1.0.23"
 termcolor = "1.1.0"
 textwrap = { version = "0.16.0", default-features = false }
 EOF
+```
+
+```txt
+Output:
+
+path = 'crates/ignore'
+version = '0.4.22'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
     <a href="https://opensource.org/licenses/MIT" rel="nofollow">
         <img alt="MIT license" src="https://img.shields.io/github/license/mdm-code/tq">
     </a>
-    <a href="https://goreportcard.com/report/github.com/mdm-code/tq">
-        <img alt="Go report card" src="https://goreportcard.com/badge/github.com/mdm-code/tq">
+    <a href="https://goreportcard.com/report/github.com/mdm-code/tq/v2">
+        <img alt="Go report card" src="https://goreportcard.com/badge/github.com/mdm-code/tq/v2">
     </a>
     <a href="https://pkg.go.dev/github.com/mdm-code/tq/v2">
         <img alt="Go package docs" src="https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white">

--- a/cmd/tq/doc.go
+++ b/cmd/tq/doc.go
@@ -30,8 +30,8 @@ Example:
 
 Output:
 
-	'10.0.0.1'
-	'10.0.0.2'
+	10.0.0.1
+	10.0.0.2
 
 Tq is a tool for querying TOML configuration files with a sequence of intuitive
 filters. It works as a regular Unix filter program reading input data from the

--- a/cmd/tq/doc.go
+++ b/cmd/tq/doc.go
@@ -16,7 +16,7 @@ Options:
 
 Example:
 
-	tq -q '.servers[].ip' <<EOF
+	<<EOF tq -q .servers[].ip
 	[servers]
 
 	[servers.prod]

--- a/cmd/tq/main_test.go
+++ b/cmd/tq/main_test.go
@@ -44,8 +44,8 @@ func TestMain(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not return an error: %s", err)
 	}
-	want := `'red'
-'green'
+	want := `red
+green
 `
 	if have := output.String(); have != want {
 		t.Errorf("have: %s\nwant: %s", have, want)

--- a/cmd/tq/usage.txt
+++ b/cmd/tq/usage.txt
@@ -15,7 +15,7 @@ Options:
 
 Example:
 
-	tq -q '.servers[].ip' <<EOF
+	<<EOF tq -q .servers[].ip
 	[servers]
 
 	[servers.prod]

--- a/cmd/tq/usage.txt
+++ b/cmd/tq/usage.txt
@@ -29,8 +29,8 @@ Example:
 
 Output:
 
-	'10.0.0.1'
-	'10.0.0.2'
+	10.0.0.1
+	10.0.0.2
 
 Tq is a tool for querying TOML configuration files with a sequence of intuitive
 filters. It works as a regular Unix filter program reading input data from the

--- a/example_test.go
+++ b/example_test.go
@@ -38,7 +38,7 @@ role = "backend"
 	_ = tq.Run(input, &output, query)
 	fmt.Println(output.String())
 	// Output:
-	// '10.0.0.1'
+	// 10.0.0.1
 }
 
 // ExampleTq_Validate shows how to use the Tq struct to validate whether a

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -1,8 +1,6 @@
 package interpreter
 
 import (
-	"fmt"
-
 	"github.com/mdm-code/tq/v2/internal/ast"
 )
 
@@ -110,7 +108,7 @@ func (i *Interpreter) VisitSpan(e ast.Expr) {
 				default:
 					err = &Error{
 						data:   d,
-						filter: fmt.Sprintf("%s", span),
+						filter: span.String(),
 						err:    ErrTOMLDataType,
 					}
 				}
@@ -136,13 +134,11 @@ func (i *Interpreter) VisitIterator(e ast.Expr) {
 						result = append(result, val)
 					}
 				case []any:
-					for _, val := range v {
-						result = append(result, val)
-					}
+					result = append(result, v...)
 				default:
 					err = &Error{
 						data:   d,
-						filter: fmt.Sprintf("%s", iter),
+						filter: iter.String(),
 						err:    ErrTOMLDataType,
 					}
 				}
@@ -172,7 +168,7 @@ func (i *Interpreter) VisitString(e ast.Expr) {
 				default:
 					err = &Error{
 						data:   d,
-						filter: fmt.Sprintf("%s", str),
+						filter: str.String(),
 						err:    ErrTOMLDataType,
 					}
 				}
@@ -201,7 +197,7 @@ func (i *Interpreter) VisitInteger(e ast.Expr) {
 				default:
 					err = &Error{
 						data:   d,
-						filter: fmt.Sprintf("%s", integer),
+						filter: integer.String(),
 						err:    ErrTOMLDataType,
 					}
 				}

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -12,7 +12,7 @@ const (
 	// lexerOffsetStart declares the initial Lexer offset.
 	lexerOffsetStart = 0
 
-	// lexerLineOffsetStart declares the inital Lexer line offset.
+	// lexerLineOffsetStart declares the initial Lexer line offset.
 	lexerLineOffsetStart = 0
 )
 

--- a/tq.go
+++ b/tq.go
@@ -93,7 +93,7 @@ func (t *Tq) Run(input io.Reader, output io.Writer, query string) error {
 		if len(bytes) == 0 {
 			continue
 		}
-		fmt.Fprintln(output, string(bytes))
+		fmt.Fprintf(output, "%s\n", strings.TrimSpace(string(bytes)))
 	}
 	return nil
 }

--- a/tq.go
+++ b/tq.go
@@ -86,12 +86,17 @@ func (t *Tq) Run(input io.Reader, output io.Writer, query string) error {
 		return err
 	}
 	for _, d := range filteredData {
-		bytes, err := t.adapter.Marshal(d)
-		if err != nil {
-			return err
-		}
-		if len(bytes) == 0 {
-			continue
+		var bytes []byte
+		var err error
+		switch v := d.(type) {
+		// NOTE: Single strings get quoted when marshalled, and it is misleading.
+		case string:
+			bytes = []byte(v)
+		default:
+			bytes, err = t.adapter.Marshal(v)
+			if err != nil {
+				return err
+			}
 		}
 		fmt.Fprintf(output, "%s\n", strings.TrimSpace(string(bytes)))
 	}


### PR DESCRIPTION
- **Trimmed the intermediate output trailing newline**
- **Replaced non-idiomatic code in the interpreter**
- **Rendered single output strings without quotes**
- **Aligned documentation with changes done to quoting**